### PR TITLE
fix failure to fully sort diff cov sample

### DIFF
--- a/multikey_qsort.h
+++ b/multikey_qsort.h
@@ -617,14 +617,14 @@ void mkeyQSortSuf2(
         }
         // Do not recurse on ='s if the pivot was the off-the-end value;
         // they're already fully sorted
-        if(v != hi) { // recurse on ='s
+        //if(v != hi) { // recurse on ='s
             block_list.back().expand();
             block_list.back().back().begin = begin + r;
             block_list.back().back().end = begin + r + (a-begin) + (end-d-1);
             block_list.back().back().depth = depth + 1;
-        }
+	    //}
         r = d-c;   // r <- # of >'s excluding those exhausted
-        if(r > 0 && v < hi-1) { // recurse on >'s
+        if(r > 0 /*&& v < hi-1*/) { // recurse on >'s
             block_list.back().expand();
             block_list.back().back().begin = end - r;
             block_list.back().back().end = end;


### PR DESCRIPTION
The parallelization scheme depends on the proper initialization of the boundaries list in the `mkeyQSortSuf2` function.  I found it was sometimes missing some boundaries.  It turned out this was because of cases where it function was avoiding recursion on size-1 ranges involving the dollar sign.  I.e. cases when the pivot equals $ (in which case the = bucket will have 1 element) or when the pivot equals T (in which case the > bucket can have at most 1 element).  But we need the recursion to happen in order for `boundaries` to be set correctly.  My fix is to comment out those $-related checks so that the recursion happens anyway in those cases.