### PR TITLE
HISAT2 Repeat API. Support MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -453,11 +453,11 @@ libhisat2lib.a: $(HT2LIB_RELEASE_OBJS)
 
 libhisat2lib-debug.so: $(HT2LIB_SHARED_DEBUG_OBJS)
 	$(CXX) $(DEBUG_FLAGS) $(DEBUG_DEFS) $(EXTRA_FLAGS) $(DEFS) $(SRA_DEF) -DBOWTIE2 -Wall $(INC) $(SEARCH_INC) \
-	-shared -Wl,-soname,$@ -o $@  $(HT2LIB_SHARED_DEBUG_OBJS) $(LIBS) $(SRA_LIB) $(SEARCH_LIBS)
+	-shared -o $@  $(HT2LIB_SHARED_DEBUG_OBJS) $(LIBS) $(SRA_LIB) $(SEARCH_LIBS)
 
 libhisat2lib.so: $(HT2LIB_SHARED_RELEASE_OBJS)
 	$(CXX) $(RELEASE_FLAGS) $(RELEASE_DEFS) $(EXTRA_FLAGS) $(DEFS) $(SRA_DEF) -DBOWTIE2 $(NOASSERT_FLAGS) -Wall  $(INC) $(SEARCH_INC)\
-	-shared -Wl,-soname,$@ -o $@ $(HT2LIB_SHARED_RELEASE_OBJS) $(LIBS) $(SRA_LIB) $(SEARCH_LIBS)
+	-shared -o $@ $(HT2LIB_SHARED_RELEASE_OBJS) $(LIBS) $(SRA_LIB) $(SEARCH_LIBS)
 	
 .ht2lib-obj-debug/%.o: %.cpp
 	@mkdir -p $(dir $@)/$(dir $<)

--- a/hisat2lib/java_jni/Makefile
+++ b/hisat2lib/java_jni/Makefile
@@ -23,9 +23,25 @@ HISAT2_DIR = ../..
 
 CC = gcc
 
-INCLUDES = -I $(JAVA_HOME)/include \
-		   -I $(JAVA_HOME)/include/linux \
-		   -I $(HISAT2_DIR)/hisat2lib
+
+MACOS = 0
+ifneq (,$(findstring Darwin,$(shell uname)))
+MACOS = 1
+endif
+
+INCLUDES = -I $(JAVA_HOME)/include
+INCLUDES += -I $(JAVA_HOME)/include/linux
+
+TARGET_LIB = libht2jni.so
+SHARED_FLAG = -shared
+
+ifeq (1,$(MACOS))
+INCLUDES += -I $(JAVA_HOME)/include/darwin
+TARGET_LIB = libht2jni.jnilib
+SHARED_FLAG = -dynamiclib
+endif
+
+INCLUDES += -I $(HISAT2_DIR)/hisat2lib
 
 CFLAGS = -fPIC $(INCLUDES)
 #CFLAGS += -DDEBUG
@@ -36,16 +52,13 @@ OBJS = $(SRCS:.c=.o)
 
 all: lib 
 
-lib: libht2jni.so
+lib: $(TARGET_LIB)
 
-libht2jni.so: HT2Module.h $(OBJS)
-	$(CC) -shared -o $@ $(OBJS) $(HISAT2_DIR)/libhisat2lib.a -lstdc++
+$(TARGET_LIB): HT2Module.h $(OBJS)
+	$(CC) $(SHARED_FLAG) -o $@ $(OBJS) $(HISAT2_DIR)/libhisat2lib.a -lstdc++
 
-HT2Module.h: HT2Module.class
-	javah HT2Module
-
-HT2Module.class: HT2Module.java
-	javac HT2Module.java
+HT2Module.h HT2Module.class: HT2Module.java
+	javac -h . HT2Module.java
 
 example: HT2ModuleExample.class
 
@@ -53,7 +66,7 @@ HT2ModuleExample.class: HT2ModuleExample.java
 	javac HT2ModuleExample.java
 
 clean:
-	rm -f *.class HT2Module.h HT2Module_HT2Position.h *.so *.o
+	rm -f *.class HT2Module.h HT2Module_HT2Position.h *.so *.o $(TARGET_LIB)
 
 test: all example
 	java -Djava.library.path=. HT2ModuleExample

--- a/hisat2lib/pymodule/Makefile
+++ b/hisat2lib/pymodule/Makefile
@@ -20,7 +20,7 @@
 all: lib
 
 lib:
-	python ./setup.py build
+	ARCHFLAGS="-arch x86_64" python ./setup.py build
 
 install:
 	python ./setup.py install


### PR DESCRIPTION
- java_jni requires JDK >= 1.8.0