### PR TITLE
subprocess.PIPE is a bytes

### DIFF
--- a/hisat2_extract_snps_haplotypes_UCSC.py
+++ b/hisat2_extract_snps_haplotypes_UCSC.py
@@ -355,7 +355,7 @@ def main(genome_file,
                                 stdout=subprocess.PIPE,
                                 stderr=open("/dev/null", 'w'))
     ids_seen = set()
-    for line in snp_proc.stdout:
+    for line in snp_proc.stdout.encode('utf-8):
         if not line or line.startswith('#'):
             continue
 


### PR DESCRIPTION
- It may raise an error if call bytes.startswith('str')